### PR TITLE
Neil

### DIFF
--- a/orca-operator.0.1.0.clusterserviceversion.yaml
+++ b/orca-operator.0.1.0.clusterserviceversion.yaml
@@ -15,7 +15,17 @@ metadata:
 spec: 
   customresourcedefinitions: 
     owned: 
-      - description: "Orca agent configuration"
+      - kind: neil
+        name: neil.neil
+        version: v1alpha1
+        displayName: AquaCsp
+        description: Aqua Security CSP Deployment with Aqua Operator    
+      - kind: neil22
+        name: neil.neil222
+        version: nneeila122
+        displayName: neilllneilllsfsf
+        description: "Orca agent configuration"
+        
         displayName: Orca
         kind: Orca
         name: orcas.tufin.io

--- a/orca-operator.0.1.0.clusterserviceversion.yaml
+++ b/orca-operator.0.1.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: tufin-system
   annotations: 
     capabilities: Basic Install
-    categories: Kubernetes Security Policy Management
+    categories: Security Policy Management
     description: Installs the resources in the cluster required by Orca, a cloud-based security monitoring and enforcement platform for Kubernetes clusters, containers and microservices.
     certified: "false"
     containerImage: registry.connect.redhat.com/tufin/orca-operator

--- a/orca-operator.0.1.0.clusterserviceversion.yaml
+++ b/orca-operator.0.1.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations: 
     capabilities: Basic Install
     categories: Security Policy Management
-    description: Installs the Orca pods in the cluster required by Orca. Orca is a cloud-based security monitoring and enforcement platform for Kubernetes clusters, containers and microservices.
+    description: Installs the resources in the cluster required by Orca, a cloud-based security monitoring and enforcement platform for Kubernetes clusters, containers and microservices.
     certified: "false"
     containerImage: registry.connect.redhat.com/tufin/orca-operator
     repository: https://github.com/Tufin/orca-operator
@@ -24,7 +24,7 @@ spec:
             version: apps/v1
           - kind: ReplicaSet
         specDescriptors: 
-          - description: "Your domain in Orca - usually the name of your organization"
+          - description: "Your domain in Orca - typically the name of your organization"
             displayName: domain
             path: domain
           - description: "Your project in Orca - a friendly name for your Kubernetes cluster"
@@ -34,7 +34,7 @@ spec:
   description: |-
     Tufin Orca is a cloud-based security monitoring and enforcement platform for Kubernetes clusters, containers and microservices.
 
-    The Orca Operator installs an agent into the monitored cluster which works in combination with the Orca service to:
+    The Orca Operator installs Orca resources in your cluster. These work with the Orca cloud application to give the following functionality:
     * Monitor the cluster configuration: namespaces, containers, pods, services, network policies etc.
     * Learn and visualize the cluster connectivity
     * Build a connectivity policy (whitelist)

--- a/orca-operator.0.1.0.clusterserviceversion.yaml
+++ b/orca-operator.0.1.0.clusterserviceversion.yaml
@@ -13,7 +13,6 @@ metadata:
     createdAt: "2019-04-28T08:00:00Z"
     support: Tufin
 spec: 
-spec: 
   customresourcedefinitions: 
     owned: 
       - description: "Orca agent configuration"

--- a/orca-operator.0.1.0.clusterserviceversion.yaml
+++ b/orca-operator.0.1.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: tufin-system
   annotations: 
     capabilities: Basic Install
-    categories: Security Policy Management
+    categories: Kubernetes Security Policy Management
     description: Installs the resources in the cluster required by Orca, a cloud-based security monitoring and enforcement platform for Kubernetes clusters, containers and microservices.
     certified: "false"
     containerImage: registry.connect.redhat.com/tufin/orca-operator

--- a/orca-operator.0.1.0.clusterserviceversion.yaml
+++ b/orca-operator.0.1.0.clusterserviceversion.yaml
@@ -13,19 +13,10 @@ metadata:
     createdAt: "2019-04-28T08:00:00Z"
     support: Tufin
 spec: 
+spec: 
   customresourcedefinitions: 
     owned: 
-      - kind: neil
-        name: neil.neil
-        version: v1alpha1
-        displayName: AquaCsp
-        description: Aqua Security CSP Deployment with Aqua Operator    
-      - kind: neil22
-        name: neil.neil222
-        version: nneeila122
-        displayName: neilllneilllsfsf
-        description: "Orca agent configuration"
-        
+      - description: "Orca agent configuration"
         displayName: Orca
         kind: Orca
         name: orcas.tufin.io
@@ -34,7 +25,7 @@ spec:
             version: apps/v1
           - kind: ReplicaSet
         specDescriptors: 
-          - description: "Your domain in Orca - typically the name of your organization"
+          - description: "Your domain in Orca - usually the name of your organization"
             displayName: domain
             path: domain
           - description: "Your project in Orca - a friendly name for your Kubernetes cluster"

--- a/orca-operator.0.1.0.clusterserviceversion.yaml
+++ b/orca-operator.0.1.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations: 
     capabilities: Basic Install
     categories: Security Policy Management
-    description: Installs an agent in the cluster that works with Tufin Orca to enable security policy management.
+    description: Installs the Orca pods in the cluster required by Orca. Orca is a cloud-based security monitoring and enforcement platform for Kubernetes clusters, containers and microservices.
     certified: "false"
     containerImage: registry.connect.redhat.com/tufin/orca-operator
     repository: https://github.com/Tufin/orca-operator


### PR DESCRIPTION
1. I changed "agent" to "resources" because it's not just the agent that gets installed (i think!) Should we mention the other resources too (dns, istio, policy crd..)?
2. Note that specDescriptors section (under heading custom resources definitions) doesn't show up on the preview screen. Is that intentional or is it a syntax error? The Aqua example doesn't use spec descriptors